### PR TITLE
Fix x64 architecture string in Plugin Utility

### DIFF
--- a/XRTK.Ultraleap/Packages/com.xrtk.ultraleap/Editor/UltraleapPluginUtility.cs
+++ b/XRTK.Ultraleap/Packages/com.xrtk.ultraleap/Editor/UltraleapPluginUtility.cs
@@ -134,12 +134,12 @@ namespace XRTK.Ultraleap.Editor
             x64Importer.ClearSettings();
             x64Importer.SetCompatibleWithAnyPlatform(false);
             x64Importer.SetCompatibleWithEditor(true);
-            x64Importer.SetEditorData("CPU", "x64");
+            x64Importer.SetEditorData("CPU", "x86_64");
             x64Importer.SetPlatformData(BuildTarget.NoTarget, "CPU", "x64");
             x64Importer.SetCompatibleWithPlatform(BuildTarget.StandaloneWindows64, true);
-            x64Importer.SetPlatformData(BuildTarget.StandaloneWindows64, "CPU", "x64");
+            x64Importer.SetPlatformData(BuildTarget.StandaloneWindows64, "CPU", "x86_64");
             x64Importer.SetCompatibleWithPlatform(BuildTarget.WSAPlayer, true);
-            x64Importer.SetPlatformData(BuildTarget.WSAPlayer, "CPU", "X64");
+            x64Importer.SetPlatformData(BuildTarget.WSAPlayer, "CPU", "x86_64");
             x64Importer.SaveAndReimport();
         }
 


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fixes the plugin import for x64 targets by adjusting the metadata string to Unity's "x86_64".